### PR TITLE
added ability to define songs for after the teleporter is charged

### DIFF
--- a/CustomSoundtrack.cs
+++ b/CustomSoundtrack.cs
@@ -12,11 +12,13 @@ using System.Threading;
 using UnityEngine.SceneManagement;
 using Path = System.IO.Path;
 
-namespace CustomSoundtrack {
+namespace CustomSoundtrack
+{
 
-    [BepInPlugin("com.speeskees.customsoundtrack", "CustomSoundtrack", "2024.5.1")]
+    [BepInPlugin("com.penumbrah.customsoundtrack", "CustomSoundtrack", "2025.5.18")]
 
-    public class CustomSoundtrack : BaseUnityPlugin {
+    public class CustomSoundtrack : BaseUnityPlugin
+    {
 
         // settings
         private string playbackMode = "next";
@@ -55,7 +57,8 @@ namespace CustomSoundtrack {
         private bool locked = false;
 
         // called when the game is started
-        public void Awake() {
+        public void Awake()
+        {
 
             //// read settings from "settings.json"
 
@@ -70,14 +73,18 @@ namespace CustomSoundtrack {
 
             // read "settings.json"
             Settings settings = null;
-            try {
+            try
+            {
                 settings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(Path.Combine(pluginPath, "settings.json")));
-            } catch (Exception error) {
+            }
+            catch (Exception error)
+            {
                 log("could not parse settings.json: " + Environment.NewLine + error);
             }
 
             // load settings
-            if (settings != null) {
+            if (settings != null)
+            {
 
                 // load track directory
                 if (settings.trackPath != null && settings.trackPath != "")
@@ -91,7 +98,8 @@ namespace CustomSoundtrack {
                 if (settings.playlists != null)
                     foreach (var playlist in settings.playlists)
                         if (playlist.ContainsKey("scenes"))
-                            foreach (var scene in playlist["scenes"]) {
+                            foreach (var scene in playlist["scenes"])
+                            {
 
                                 if (!playlists.Keys.Contains(scene))
                                     playlists.Add(scene, new List<string>());
@@ -104,7 +112,7 @@ namespace CustomSoundtrack {
                                 if (playlist.ContainsKey("bossTracks"))
                                     foreach (var bossTrack in playlist["bossTracks"])
                                         bossPlaylists[scene].Add(Path.Combine(trackPath, bossTrack));
-                                
+
                                 if (!postBossPlaylists.Keys.Contains(scene))
                                     postBossPlaylists.Add(scene, new List<string>());
                                 if (playlist.ContainsKey("postBossTracks"))
@@ -121,27 +129,31 @@ namespace CustomSoundtrack {
                 .Where(fileName => fileName.ToLower().EndsWith(".aiff") || fileName.ToLower().EndsWith(".mp3") || fileName.ToLower().EndsWith(".wav")))
                 playlists["_default"].Add(track);
 
-            if (logging) {
+            if (logging)
+            {
 
                 log("track directory: " + trackPath);
                 log("playback mode: " + playbackMode);
 
                 log("playlists: ");
-                foreach (var scene in playlists.Keys) {
+                foreach (var scene in playlists.Keys)
+                {
                     log("    " + scene + ": ");
                     foreach (var track in playlists[scene])
                         log("        " + track);
                 }
 
                 log("boss playlists: ");
-                foreach (var scene in bossPlaylists.Keys) {
+                foreach (var scene in bossPlaylists.Keys)
+                {
                     log("    " + scene + ": ");
                     foreach (var track in bossPlaylists[scene])
                         log("        " + track);
                 }
 
                 log("tp playlists: ");
-                foreach (var scene in postBossPlaylists.Keys) {
+                foreach (var scene in postBossPlaylists.Keys)
+                {
                     log("    " + scene + ": ");
                     foreach (var track in postBossPlaylists[scene])
                         log("        " + track);
@@ -157,7 +169,8 @@ namespace CustomSoundtrack {
                 if (scene.name == "splash")
                     start = true;
 
-                if (start && currentScene != scene.name) {
+                if (start && currentScene != scene.name)
+                {
                     currentState = GameState.Normal;
                     currentPlaylist = playlists["_default"];
                     currentScene = scene.name;
@@ -175,7 +188,7 @@ namespace CustomSoundtrack {
 
                 orig(self, activator);
 
-                if (currentState != GameState.BossFight)
+                if (currentState != GameState.BossFight && currentState != GameState.PostBoss)
                 {
                     currentState = GameState.BossFight;
                     nextPlaylist();
@@ -189,14 +202,15 @@ namespace CustomSoundtrack {
             // when tp event ends
             RoR2.TeleporterInteraction.onTeleporterChargedGlobal += (TeleporterInteraction teleporterInteraction) => {
 
-                if (currentState != GameState.PostBoss) {
+                if (currentState != GameState.PostBoss)
+                {
                     currentState = GameState.PostBoss;
                     nextPlaylist();
                 }
 
                 if (logging)
                     log("tp event over");
-                
+
             };
 
             // when the mithrix fight starts
@@ -204,7 +218,8 @@ namespace CustomSoundtrack {
 
                 orig(self);
 
-                if (currentState != GameState.BossFight) {
+                if (currentState != GameState.BossFight)
+                {
                     currentState = GameState.BossFight;
                     nextPlaylist();
                 }
@@ -219,7 +234,8 @@ namespace CustomSoundtrack {
 
                 orig(self);
 
-                if (currentState != GameState.PostBoss) {
+                if (currentState != GameState.PostBoss)
+                {
                     currentState = GameState.PostBoss;
                     nextPlaylist();
                 }
@@ -234,7 +250,8 @@ namespace CustomSoundtrack {
 
                 orig(self);
 
-                if (currentState != GameState.BossFight) {
+                if (currentState != GameState.BossFight)
+                {
                     currentState = GameState.BossFight;
                     nextPlaylist();
                 }
@@ -247,9 +264,10 @@ namespace CustomSoundtrack {
             // when the false son fight ends
             On.EntityStates.MeridianEvent.Phase3.OnExit += (orig, self) => {
 
-                orig(self); 
+                orig(self);
 
-                if (currentState != GameState.Normal) {
+                if (currentState != GameState.Normal)
+                {
                     currentState = GameState.Normal;
                     nextPlaylist();
                 }
@@ -264,13 +282,15 @@ namespace CustomSoundtrack {
 
                 orig(self, isFocussed);
 
-                if (isFocussed && player.PlaybackState == PlaybackState.Paused) {
+                if (isFocussed && player.PlaybackState == PlaybackState.Paused)
+                {
                     paused = false;
                     if (!locked)
                         player.Play();
                 }
 
-                if (!isFocussed && player.PlaybackState == PlaybackState.Playing) {
+                if (!isFocussed && player.PlaybackState == PlaybackState.Playing)
+                {
                     paused = true;
                     if (!locked)
                         player.Pause();
@@ -284,18 +304,21 @@ namespace CustomSoundtrack {
 
         }
 
-        private void disableOriginalSoundtrack(On.RoR2.MusicTrackOverride.orig_PickMusicTrack orig, MusicController self, ref MusicTrackDef track) {
+        private void disableOriginalSoundtrack(On.RoR2.MusicTrackOverride.orig_PickMusicTrack orig, MusicController self, ref MusicTrackDef track)
+        {
             orig(self, ref track);
             track = null;
         }
 
-        private void disableOriginalSoundtrack(On.RoR2.MusicController.orig_PickCurrentTrack orig, MusicController self, ref MusicTrackDef track) {
+        private void disableOriginalSoundtrack(On.RoR2.MusicController.orig_PickCurrentTrack orig, MusicController self, ref MusicTrackDef track)
+        {
             orig(self, ref track);
             track = null;
         }
 
         // called on every frame
-        public void Update() {
+        public void Update()
+        {
 
             // play the next track if playback has stopped
             if (start && !locked && player.PlaybackState == PlaybackState.Stopped)
@@ -306,7 +329,8 @@ namespace CustomSoundtrack {
         }
 
         // select and start playing the next playlist
-        private void nextPlaylist() {
+        private void nextPlaylist()
+        {
 
             // try to find a playlist for the current stage
             // if no playlist is found, the default playlist is used
@@ -329,7 +353,8 @@ namespace CustomSoundtrack {
             }
 
             // if playbackMode is set to "next", leave the playlist unchanged and start playing the first track
-            if (playbackMode == "next") {
+            if (playbackMode == "next")
+            {
                 nextTrack();
                 return;
             }
@@ -337,7 +362,8 @@ namespace CustomSoundtrack {
             // if playbackMode is set to "shuffle", randomize the playlist and start playing the first track
             var randomizer = new Random();
             currentPlaylist = currentPlaylist.OrderBy(_ => randomizer.Next()).ToList();
-            if (playbackMode == "shuffle") {
+            if (playbackMode == "shuffle")
+            {
                 nextTrack();
                 return;
             }
@@ -349,13 +375,16 @@ namespace CustomSoundtrack {
         }
 
         // select and start the next track
-        private void nextTrack() {
+        private void nextTrack()
+        {
 
-            if (currentPlaylist.Count > 0) {
+            if (currentPlaylist.Count > 0)
+            {
 
                 // select the first track from the current playlist
                 var nextTrack = currentPlaylist[0];
-                if (nextTrack != currentTrack || player.PlaybackState == PlaybackState.Stopped) {
+                if (nextTrack != currentTrack || player.PlaybackState == PlaybackState.Stopped)
+                {
 
                     var oldFadeInOutSampleProvider = currentFadeInOutSampleProvider;
 
@@ -370,7 +399,8 @@ namespace CustomSoundtrack {
 
                     applyVolume();
 
-                    if (logging) {
+                    if (logging)
+                    {
 
                         log("current track: " + currentTrack);
 
@@ -380,7 +410,8 @@ namespace CustomSoundtrack {
 
                     }
 
-                    if (!locked) {
+                    if (!locked)
+                    {
 
                         locked = true;
 
@@ -390,7 +421,8 @@ namespace CustomSoundtrack {
                         new Thread(() => {
 
                             // if still playing, fade out the current track and stop playing
-                            if (player.PlaybackState != PlaybackState.Stopped) {
+                            if (player.PlaybackState != PlaybackState.Stopped)
+                            {
 
                                 oldTrack.BeginFadeOut(1500);
                                 Thread.Sleep(1500);
@@ -416,8 +448,10 @@ namespace CustomSoundtrack {
         }
 
         // read and apply the volume from the settings menu to the current track
-        private void applyVolume() {
-            if (currentAudioFileReader != null) {
+        private void applyVolume()
+        {
+            if (currentAudioFileReader != null)
+            {
                 float.TryParse(AudioManager.cvVolumeMaster.GetString(), out float masterVolume);
                 float.TryParse(AudioManager.cvVolumeMsx.GetString(), out float musicVolume);
                 masterVolume /= 100f;
@@ -426,13 +460,15 @@ namespace CustomSoundtrack {
             }
         }
 
-        private void log(string message) {
+        private void log(string message)
+        {
             File.AppendAllText(logPath, "[" + DateTime.Now.ToString("hh:mm:ss") + "] " + message + Environment.NewLine);
         }
 
     }
 
-    public class Settings {
+    public class Settings
+    {
         public string playbackMode { get; set; }
         public string trackPath { get; set; }
         public List<Dictionary<string, List<string>>> playlists { get; set; }

--- a/CustomSoundtrack.csproj
+++ b/CustomSoundtrack.csproj
@@ -1,19 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MMHOOK.RoR2"
-						  Version="2022.9.20">
+		<PackageReference Include="BepInEx.BaseLib" Version="5.4.21" />
+		<PackageReference Include="MMHOOK.RoR2" Version="2025.5.5">
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
-		<PackageReference Include="NAudio"
-						  Version="1.10.0" />
-		<PackageReference Include="RoR2BepInExPack"
-						  Version="1.7.0" />
+		<PackageReference Include="NAudio" Version="1.10.0" />
+		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.8-r.0" />
+		<PackageReference Include="RoR2BepInExPack" Version="1.7.0" />
 	</ItemGroup>
+
+	<Target Name="CopyNAudioDependencies" AfterTargets="Build">
+		<ItemGroup>
+			<NAudioFiles Include="$(NuGetPackageRoot)naudio\1.10.0\lib\netstandard2.0\*.dll" />
+		</ItemGroup>
+		<Copy SourceFiles="@(NAudioFiles)" DestinationFolder="$(OutputPath)" />
+	</Target>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,42 @@
-## TODO write a better readme
+# RoR2 Custom Soundtrack
 
-An overhaul of [EtiTheSpirt's fork](https://github.com/EtiTheSpirit/RoR2-Original-Sound-Track/tree/master) of [Kyle Paulsen's OriginalSoundTrack mod](https://github.com/kylepaulsen/RoR2-Original-Sound-Track).
+A comprehensive overhaul of the original Risk of Rain 2 soundtrack mod, allowing you to replace the game's music with your own custom tracks.
 
-The following improvements were made:
+## Features
 
-- the settings file has been rewritten in json
-- prevented a game freeze when switching tracks
-- added logging to help debug issues with the settings file, only enabled when there is no log yet
-- implemented getting volume from the ingame sliders
-- added all scenes since 1.5.2024 to the settings file
+- **Complete Event Coverage**: Supports all game events including:
+  - Regular stage music
+  - Boss fights
+  - Post-boss events
+  - Prime Meridian event (Seekers of the Storm DLC)
+  - All scenes and events since 1.5.2024
 
-Should be pretty straightforward to use, just have a look at settings.json. For more information, visit [Kyle Paulsen's OriginalSoundTrack mod](https://github.com/kylepaulsen/RoR2-Original-Sound-Track).
+- **Multiplayer Support**: Works seamlessly in multiplayer games, even when other players trigger boss events
+
+- **User-Friendly Configuration**:
+  - JSON-based settings file for easy customization
+  - Automatic volume control using in-game sliders
+  - Detailed logging system for troubleshooting
+
+- **Performance & Stability**:
+  - No game freezes when switching tracks
+  - Optimized track switching
+  - Reliable event detection
+
+## Installation
+
+1. Download the latest release
+2. Place the mod in your Risk of Rain 2 mods folder
+3. Configure your music in `settings.json`
+
+## Configuration
+
+Check `settings.json` to customize which music plays during different game events. The file is well-documented and easy to modify.
+
+## Credits
+
+This mod is a complete overhaul of [Speeskees' fork](https://github.com/Speeskees/RoR2-Custom-Soundtrack) of [EtiTheSpirt's fork](https://github.com/EtiTheSpirit/RoR2-Original-Sound-Track) of [Kyle Paulsen's OriginalSoundTrack mod](https://github.com/kylepaulsen/RoR2-Original-Sound-Track), with significant improvements and new features.
+
+## License
+
+MIT License

--- a/settings.json
+++ b/settings.json
@@ -24,17 +24,20 @@
         {
             "scenes": [ "goolake", "itgoolake" ], // Abandoned Aqueduct
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "dampcavesimple", "itdampcave" ], // Abyssal Depths
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "ancientloft", "itancientloft" ], // Aphelian Sanctuary
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "bazaar" ], // Bazaar Between Time
@@ -47,12 +50,14 @@
         {
             "scenes": [ "moon", "moon2", "itmoon" ], // Commencement
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "blackbeach", "blackbeach2" ], // Distant Roost
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "goldshores" ], // Gilded Coast
@@ -65,37 +70,44 @@
         {
             "scenes": [ "frozenwall", "itfrozenwall" ], // Rallypoint Delta
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "wispgraveyard" ], // Scorched Acres
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "snowyforest" ], // Siphoned Forest
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "shipgraveyard" ], // Siren's Call
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "skymeadow", "itskymeadow" ], // Sky Meadow
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "sulfurpools" ], // Sulfur Pools
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "rootjungle" ], // Sundered Grove
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "voidraid" ], // The Planetarium
@@ -104,7 +116,8 @@
         {
             "scenes": [ "golemplains", "golemplains2", "itgolemplains" ], // Titanic Plains
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
             "scenes": [ "arena" ], // Void Fields
@@ -117,7 +130,8 @@
         {
             "scenes": [ "foggyswamp" ], // Wetland Aspect
             "tracks": [],
-            "bossTracks": []
+            "bossTracks": [],
+            "postBossTracks": []
         }
     ]
 

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
-    // scenes up to date as of 1.5.2024
+    // scenes up to date as of 5.18.2025
 
     // where the mod should look for music tracks
     // leave empty to use plugin directory
@@ -14,124 +14,168 @@
     // a list of scene names can be found here: https://risk-of-thunder.github.io/R2Wiki/Mod-Creation/Developer-Reference/Scene-Names/
     "playlists": [
         {
-            "scenes": [ "mysteryspace" ], // A Moment, Fractured
-            "tracks": [ "example.mp3", "folder/example2.mp3" ]
+            "scenes": ["ancientloft", "itancientloft"], // aphelian sanctuary
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
         },
         {
-            "scenes": [ "limbo" ], // A Moment, Whole
+            "scenes": ["arena"], // void fields
             "tracks": []
         },
         {
-            "scenes": [ "goolake", "itgoolake" ], // Abandoned Aqueduct
+            "scenes": ["blackbeach", "blackbeach2"], // distant roost
             "tracks": [],
             "bossTracks": [],
             "postBossTracks": []
         },
         {
-            "scenes": [ "dampcavesimple", "itdampcave" ], // Abyssal Depths
+            "scenes": ["dampcavesimple", "itdampcave"], // abyssal depths
             "tracks": [],
             "bossTracks": [],
             "postBossTracks": []
         },
         {
-            "scenes": [ "ancientloft", "itancientloft" ], // Aphelian Sanctuary
+            "scenes": ["foggyswamp"], // wetland aspect
             "tracks": [],
             "bossTracks": [],
             "postBossTracks": []
         },
         {
-            "scenes": [ "bazaar" ], // Bazaar Between Time
+            "scenes": ["frozenwall", "itfrozenwall"], // rallypoint delta
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["golemplains", "golemplains2", "itgolemplains"], // titanic plains
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["goolake", "itgoolake"], // abandoned aqueduct
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["habitat", "habitatfall"], // treeborn colony, golden dieback
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["helminthroost"], // helminth hatchery
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["lakes", "lakesnight"], // verdant falls, viscous falls
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["lemuriantemple"], // reformed altar
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["meridian"], // prime meridian
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["moon2", "itmoon"], // commencement
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["rootjungle"], // sundered grove
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["shipgraveyard"], // siren's call
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["skymeadow", "itskymeadow"], // sky meadow
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["snowyforest"], // siphoned forest
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["sulfurpools"], // sulfur pools
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["village", "villagenight"], // shattered abodes, disturbed impact
+            "tracks": [],
+            "bossTracks": [],
+            "postBossTracks": []
+        },
+        {
+            "scenes": ["voidraid"], // the planetarium
             "tracks": []
         },
         {
-            "scenes": [ "artifactworld" ], // Bulwark's Ambry
+            "scenes": ["voidstage"], // void locus
             "tracks": []
         },
         {
-            "scenes": [ "moon", "moon2", "itmoon" ], // Commencement
+            "scenes": ["wispgraveyard"], // scorched acres
             "tracks": [],
             "bossTracks": [],
             "postBossTracks": []
         },
         {
-            "scenes": [ "blackbeach", "blackbeach2" ], // Distant Roost
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "goldshores" ], // Gilded Coast
+            "scenes": ["artifactworld", "artifactworld01", "artifactworld02", "artifactworld03"], // bulwark's ambry
             "tracks": []
         },
         {
-            "scenes": [ "crystalworld", "eclipseworld", "infinitetowerworld", "intro", "loadingbasic", "lobby", "logbook", "outro", "splash", "title" ], // Main Menu
+            "scenes": ["bazaar"], // bazaar
             "tracks": []
         },
         {
-            "scenes": [ "frozenwall", "itfrozenwall" ], // Rallypoint Delta
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "wispgraveyard" ], // Scorched Acres
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "snowyforest" ], // Siphoned Forest
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "shipgraveyard" ], // Siren's Call
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "skymeadow", "itskymeadow" ], // Sky Meadow
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "sulfurpools" ], // Sulfur Pools
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "rootjungle" ], // Sundered Grove
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "voidraid" ], // The Planetarium
+            "scenes": ["goldshores"], // gilded coast
             "tracks": []
         },
         {
-            "scenes": [ "golemplains", "golemplains2", "itgolemplains" ], // Titanic Plains
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
-        },
-        {
-            "scenes": [ "arena" ], // Void Fields
+            "scenes": ["limbo"], // a moment, whole
             "tracks": []
         },
         {
-            "scenes": [ "voidstage" ], // Void Locus
+            "scenes": ["mysteryspace"], // a moment, fractured
             "tracks": []
         },
         {
-            "scenes": [ "foggyswamp" ], // Wetland Aspect
-            "tracks": [],
-            "bossTracks": [],
-            "postBossTracks": []
+            "scenes": ["crystalworld", "eclipseworld", "infinitetowerworld", "intro", "loadingbasic", "logbook", "splash", "title"], // main menu
+            "tracks": []
+        },
+        {
+            "scenes": ["lobby"], // character select
+            "tracks": []
+        },
+        {
+            "scenes": ["outro"], // credits
+            "tracks": []
         }
     ]
 


### PR DESCRIPTION
I was using the mod to add custom music, but the boss music was typically really loud and once the teleporter was done and we were scrapping (as you do) me and my friend would have to listen to the boss music when nothing was happening so I added the ability to define music after the teleporter is charged